### PR TITLE
arm64/pinephone: Add driver for Frame Buffer

### DIFF
--- a/Documentation/platforms/arm/a64/boards/pinephone/index.rst
+++ b/Documentation/platforms/arm/a64/boards/pinephone/index.rst
@@ -157,6 +157,7 @@ Peripheral              Support NOTES
 ======================= ======= =====
 Backlight                Yes
 Display Engine           Yes
+Frame Buffer             Yes
 LCD Controller (ST7703)  Yes
 LCD Panel (XBD599)       Yes
 MIPI D-PHY               Yes

--- a/boards/arm64/a64/pinephone/src/pinephone_display.h
+++ b/boards/arm64/a64/pinephone/src/pinephone_display.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm64/a64/pinephone/src/pinephone_bringup.c
+ * boards/arm64/a64/pinephone/src/pinephone_display.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,79 +18,35 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM64_A64_PINEPHONE_SRC_PINEPHONE_DISPLAY_H
+#define __BOARDS_ARM64_A64_PINEPHONE_SRC_PINEPHONE_DISPLAY_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sys/types.h>
-#include <syslog.h>
-
-#ifdef CONFIG_FS_PROCFS
-#  include <nuttx/fs/fs.h>
-#endif
-
-#ifdef CONFIG_USERLED
-#  include <nuttx/leds/userled.h>
-#endif
-
-#ifdef CONFIG_VIDEO_FB
-#  include <nuttx/video/fb.h>
-#  include "pinephone_display.h"
-#endif
-
-#include "pinephone.h"
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pinephone_bringup
+ * Name: pinephone_display_test_pattern
  *
  * Description:
- *   Bring up board features
+ *   Fill the 3 Frame Buffers with a Test Pattern.  Should be called after
+ *   Display Engine is Enabled, or the rendered image will have missing
+ *   rows.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
  *
  ****************************************************************************/
 
-int pinephone_bringup(void)
-{
-  int ret;
+void pinephone_display_test_pattern(void);
 
-#ifdef CONFIG_USERLED
-  /* Register the LED driver */
-
-  ret = userled_lower_initialize("/dev/userleds");
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
-    }
-#endif
-
-#ifdef CONFIG_FS_PROCFS
-  /* Mount the procfs file system */
-
-  ret = nx_mount(NULL, "/proc", "procfs", 0, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to mount procfs at /proc: %d\n", ret);
-    }
-#endif
-
-#ifdef CONFIG_VIDEO_FB
-  /* Initialize and register the framebuffer driver */
-
-  ret = fb_register(0, 0);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: fb_register() failed: %d\n", ret);
-    }
-
-  /* Render the Test Pattern */
-
-  pinephone_display_test_pattern();
-#endif
-
-  UNUSED(ret);
-  return OK;
-}
+#endif /* __BOARDS_ARM64_A64_PINEPHONE_SRC_PINEPHONE_DISPLAY_H */


### PR DESCRIPTION
## Summary

This PR adds the Frame Buffer Driver for PINE64 PinePhone. With this driver, NuttX Apps will be able to use the standard Frame Buffer API to render graphics on PinePhone.

### Modified Files

`boards/arm64/a64/pinephone/src/pinephone_bringup.c`: Render Test Pattern after calling `up_fbinitialize()` to start the Frame Buffer Driver

`boards/arm64/a64/pinephone/src/pinephone_display.c`: Add Frame Buffer Driver

### New Files

`boards/arm64/a64/pinephone/src/pinephone_display.h`: Declare new function for rendering Test Pattern

### Updated Documentation

`platforms/arm/a64/boards/pinephone/index.rst`: Add Frame Buffer as supported driver for PinePhone

## Impact

With this PR, NuttX Apps will be able to use the standard Frame Buffer API to render graphics on PinePhone.

At startup, PinePhone still renders the [Test Pattern](https://lupyuen.github.io/images/de3-title.jpg). The Test Pattern will be erased on the first app call to the Frame Buffer Driver.

## Testing

We tested the Frame Buffer Driver with the `fb` Example App.

As intended, the `fb` app renders on the First Overlay Frame Buffer, which occupies the top part of the display. [(Like this)](https://lupyuen.github.io/images/fb-test1.jpg)

To render fullscreen, we modified [fb_main.c](https://github.com/apache/nuttx-apps/blob/master/examples/fb/fb_main.c#L344) and changed this line:

```c
// Render on Frame Buffer Overlay
#ifdef CONFIG_FB_OVERLAY
```

To this...

```c
// Changed to render on Fullscreen Frame Buffer instead
#ifdef NOTUSED
```

The `fb` app now renders on the Fullscreen Frame Buffer. [(Like this)](https://lupyuen.github.io/images/fb-test2.jpg)

There are missing pixels due to an issue with DMA / Display Engine / Timing Controller TCON0. This will be fixed in another PR.

Here's the Test Log for the Fullscreen Frame Buffer:

- [Test Log for `fb` Example App](https://gist.github.com/lupyuen/7d85fbe55417538b70816aa21dfa7e32)
