### PR TITLE
arm, arm64, xtensa, libxx: Change `sed -r` to `sed -E` to support macOS

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -178,7 +178,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifneq ($(TOOLCHAIN_CLANG_CONFIG),)
     ifeq ($(CLANGVER),)
-      export CLANGVER := $(shell $(CC) --version | grep "clang version" | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/")
+      export CLANGVER := $(shell $(CC) --version | grep "clang version" | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/")
     endif
 
     ifeq ($(CLANGVER),14.0)
@@ -257,7 +257,7 @@ else
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 
   ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
   endif
 
   ifeq ($(GCCVER),12)

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -166,7 +166,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
   endif
 
   ifeq ($(GCCVER),12)

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -236,7 +236,7 @@ CHIP_CSRCS += esp32_wlan.c esp32_wifi_utils.c esp32_wifi_adapter.c
 EXTRA_LIBS += -lcore -lnet80211 -lpp -lsmartconfig -lespnow -lwpa_supplicant
 
 ifeq ($(GCCVER),)
-  export GCCVER := $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
+  export GCCVER := $(shell $(CC) --version | grep gcc | sed -E 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
 ifeq ($(GCCVER),12)
   chip/esp32_wifi_adapter.c_CFLAGS += -Wno-maybe-uninitialized

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -79,7 +79,7 @@ libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 #       |                                ^~~~~~
 
 ifeq ($(GCCVER),)
-  export GCCVER = $(shell $(CXX) --version | grep g++ | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
+  export GCCVER = $(shell $(CXX) --version | grep g++ | sed -E 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
 
 ifeq ($(GCCVER),12)


### PR DESCRIPTION
## Summary

When we build NuttX on macOS, it shows many `sed` messages (and the build still completes successfully):

```text
$ tools/configure.sh pinephone:nsh
$ make
sed: illegal option -- r
```

[(See the Complete Log)](https://gist.github.com/lupyuen/1c3f1f1d71993609bed3b31767595beb#file-pinephone-release-log-L282-L690)

This is due to the Makefiles executing `sed -r` which is not a valid option on macOS. [(As explained here)](https://github.com/apache/nuttx/pull/10655#issuecomment-1754168154)

This PR proposes to change `sed -r` to `sed -E` because:

1. `sed -E` on macOS is equivalent to `sed -r` on Linux [(See this)](https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed)

1. `sed -E` and `sed -r` are aliases according to the [GNU `sed` Manual](https://www.gnu.org/software/sed/manual/sed.html#Command_002dLine-Options)

1. `sed -E` is already used in [nuttx_add_romfs.cmake](https://github.com/apache/nuttx/blob/master/cmake/nuttx_add_romfs.cmake#L111), [nuttx_add_symtab.cmake](https://github.com/apache/nuttx/blob/master/cmake/nuttx_add_symtab.cmake#L81-L84) and [process_config.sh](https://github.com/apache/nuttx/blob/master/tools/process_config.sh#L28)

## Impact

On macOS: NuttX now builds without showing any `sed` messages.

On other platforms: There should be no impact, since `sed -E` and `sed -r` are functionally identical.

## Testing

`sed` is used by the Makefiles to extract the GCC Major Version and the Clang Major / Minor Version. We tested the `sed` commands on Linux and macOS to verify that they work correctly:

```bash
## sed 4.9 on Linux 6.3.9 (Manjaro Arm64)
$ aarch64-none-elf-gcc --version
aarch64-none-elf-gcc (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)) 12.2.1 20221205

$ aarch64-none-elf-gcc --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1
12

$ clang --version
clang version 15.0.7

$ clang --version | grep "clang version" | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/"
15.0

## sed on macOS 10.15.7
$ aarch64-none-elf-gcc --version
aarch64-none-elf-gcc (Arm GNU Toolchain 11.3.Rel1) 11.3.1 20220712

$ aarch64-none-elf-gcc --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1
11

$ clang --version
clang version 3.9.1 (tags/RELEASE_391/final)

$ clang --version | grep "clang version" | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/"
3.9
````

On macOS: NuttX now builds without showing any `sed` messages.
