### PR TITLE
risc-v/bl808: Implement Timer with OpenSBI

### DIFF
--- a/arch/risc-v/src/bl808/bl808_timerisr.c
+++ b/arch/risc-v/src/bl808/bl808_timerisr.c
@@ -29,62 +29,16 @@
 #include <time.h>
 #include <debug.h>
 
-#include <nuttx/arch.h>
-#include <nuttx/clock.h>
-#include <nuttx/init.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/timers/arch_alarm.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "riscv_mtimer.h"
-#include "riscv_percpu.h"
-#include "hardware/bl808_memorymap.h"
 
 /****************************************************************************
- * Private Data
+ * Pre-processor Definitions
  ****************************************************************************/
 
-static uint32_t g_stimer_pending = false;
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: bl808_ssoft_interrupt
- *
- * Description:
- *   This function is S-mode software interrupt handler to proceed
- *   the OS timer
- *
- ****************************************************************************/
-
-static int bl808_ssoft_interrupt(int irq, void *context, void *arg)
-{
-  /* Cleaer Supervisor Software Interrupt */
-
-  CLEAR_CSR(sip, SIP_SSIP);
-
-  if (g_stimer_pending)
-    {
-      g_stimer_pending = false;
-
-      /* Proceed the OS timer */
-
-      nxsched_process_timer();
-    }
-#ifdef CONFIG_SMP
-  else
-    {
-      /* We assume IPI has been issued */
-
-      riscv_pause_handler(irq, context, arg);
-    }
-#endif
-
-  return 0;
-}
+#define MTIMER_FREQ 1000000
 
 /****************************************************************************
  * Public Functions
@@ -101,6 +55,14 @@ static int bl808_ssoft_interrupt(int irq, void *context, void *arg)
 
 void up_timer_initialize(void)
 {
-  irq_attach(RISCV_IRQ_SSOFT, bl808_ssoft_interrupt, NULL);
-  up_enable_irq(RISCV_IRQ_SSOFT);
+  /* Initialize the OpenSBI Timer. mtime and mtimecmp are unused for
+   * OpenSBI.
+   */
+
+  struct oneshot_lowerhalf_s *lower = riscv_mtimer_initialize(
+    0, 0, RISCV_IRQ_STIMER, MTIMER_FREQ);
+
+  DEBUGASSERT(lower);
+
+  up_alarm_set_lowerhalf(lower);
 }


### PR DESCRIPTION
## Summary

The implementation of the RISC-V Timer for BL808 SoC is incomplete. This PR implements the BL808 RISC-V Timer by calling OpenSBI. The code is derived from NuttX for RISC-V QEMU.

The implementation of `up_timer_initialize` with OpenSBI is [explained in this article](https://lupyuen.github.io/articles/nim#appendix-opensbi-timer-for-nuttx).

## Impact

With this PR, `sleep` and other Timer Functions will work correctly on BL808 SoC, instead of hanging indefinitely.

No impact on other SoCs.

## Testing

We tested with `ostest` on Ox64 BL808 SBC:

```bash
$ tools/configure.sh ox64:nsh
```

### Before PR

`ostest` hangs when accessing the RISC-V Timer:

```text
nsh> ostest
...
ostest_main: Started user_main at PID=7
(Hang)
```

[(NuttX Log)](https://gist.github.com/lupyuen/37d5d2d27ed10f37e6c586b715cc33ef)

### After PR

`ostest` works correctly with the RISC-V Timer and completes without errors:

```text
nsh> ostest
...
user_main: Exiting
ostest_main: Exiting with status -1
nsh> 
```

[(NuttX Log)](https://gist.github.com/lupyuen/c90ab66092480578eed7698635cd5abe)
