### PR TITLE
Gpio5: GPIO Driver tested OK with Ox64 Emulator

### DIFF
--- a/arch/risc-v/src/bl808/Make.defs
+++ b/arch/risc-v/src/bl808/Make.defs
@@ -27,5 +27,5 @@ HEAD_ASRC = bl808_head.S
 # Specify our C code within this directory to be included
 CHIP_CSRCS  = bl808_start.c bl808_irq_dispatch.c bl808_irq.c
 CHIP_CSRCS += bl808_timerisr.c bl808_allocateheap.c
-CHIP_CSRCS += bl808_mm_init.c bl808_pgalloc.c bl808_serial.c
+CHIP_CSRCS += bl808_gpio.c bl808_mm_init.c bl808_pgalloc.c bl808_serial.c
 CHIP_CSRCS += bl808_courier.c

--- a/arch/risc-v/src/bl808/bl808_gpio.c
+++ b/arch/risc-v/src/bl808/bl808_gpio.c
@@ -1,0 +1,143 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_gpio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <sys/param.h>
+
+#include "riscv_internal.h"
+#include "hardware/bl808_glb.h"
+#include "bl808_gpio.h"
+#include "bl808_memorymap.h"
+
+#define BL808_NGPIOS 45
+#define GPIO_O_SHIFT 24
+#define GPIO_I_SHIFT 28
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_configgpio
+ *
+ * Description:
+ *   Configure a GPIO pin based on encoded pin attributes.
+ *
+ ****************************************************************************/
+
+int bl808_configgpio(int pin, gpio_pinattr_t attr)
+{
+  uintptr_t regaddr;
+  uint32_t cfg = 0;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  if (attr & GPIO_INPUT)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_IE;
+    }
+  else
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_OE;
+    }
+
+  if (attr & GPIO_PULLUP)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_PU;
+    }
+
+  if (attr & GPIO_PULLDOWN)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_PD;
+    }
+
+  if (attr & GPIO_DRV_MASK)
+    {
+      cfg |= ((attr & GPIO_DRV_MASK) >> GPIO_DRV_SHIFT) <<
+        GPIO_CFGCTL0_GPIO_0_DRV_SHIFT;
+    }
+
+  if (attr & GPIO_SMT_EN)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_SMT;
+    }
+
+  if (attr & GPIO_FUNC_MASK)
+    {
+      cfg |= ((attr & GPIO_FUNC_MASK) >> GPIO_FUNC_SHIFT) <<
+        GPIO_CFGCTL0_GPIO_0_FUNC_SEL_SHIFT;
+    }
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  putreg32(cfg, regaddr);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: bl808_gpiowrite
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void bl808_gpiowrite(int pin, bool value)
+{
+  uintptr_t regaddr;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  if (value)
+    {
+      modifyreg32(regaddr, 0, (1 << GPIO_O_SHIFT));
+    }
+  else
+    {
+      modifyreg32(regaddr, (1 << GPIO_O_SHIFT), 0);
+    }
+}
+
+/****************************************************************************
+ * Name: bl808_gpioread
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool bl808_gpioread(int pin)
+{
+  uintptr_t regaddr;
+  uint32_t regval;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  regval = getreg32(regaddr);
+  return (regval & (1 << GPIO_I_SHIFT)) != 0;
+}
+

--- a/arch/risc-v/src/bl808/bl808_gpio.h
+++ b/arch/risc-v/src/bl808/bl808_gpio.h
@@ -1,0 +1,188 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_gpio.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL808_BL808_GPIO_H
+#define __ARCH_RISCV_SRC_BL808_BL808_GPIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-Processor Declarations
+ ****************************************************************************/
+
+/* Encoded GPIO Attributes
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ..MU UDDS FFFF
+ */
+
+/* Mode:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ..M. .... ....
+ */
+
+#define GPIO_MODE_SHIFT  (9)                     /* Bit 9: Port Mode */
+#define GPIO_MODE_MASK   (1 << GPIO_MODE_SHIFT)
+#  define GPIO_INPUT     (1 << GPIO_MODE_SHIFT)  /* Input Enable */
+#  define GPIO_OUTPUT    (0 << GPIO_MODE_SHIFT)  /* Output Enable */
+
+/* Input/Output pull-ups/downs:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ...U U... ....
+ */
+
+#define GPIO_PUPD_SHIFT (7) /* Bits 7-8: Pull-up/down */
+#define GPIO_PUPD_MASK  (3 << GPIO_PUPD_SHIFT)
+#define GPIO_FLOAT      (0 << GPIO_PUPD_SHIFT) /* No pull-up, pull-down */
+#define GPIO_PULLUP     (1 << GPIO_PUPD_SHIFT) /* Pull-up */
+#define GPIO_PULLDOWN   (2 << GPIO_PUPD_SHIFT) /* Pull-down */
+
+/* Drive:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... .DD. ....
+ */
+
+#define GPIO_DRV_SHIFT (5) /* Bits 5-6: Drive */
+#define GPIO_DRV_MASK  (3 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_0     (0 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_1     (1 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_2     (2 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_3     (3 << GPIO_DRV_SHIFT)
+
+/* Input Schmitt trigger:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... ...S ....
+ */
+
+#define GPIO_SMT_SHIFT (4) /* Bit 4: SMT Enable */
+#define GPIO_SMT_MASK  (3 << GPIO_SMT_SHIFT)
+#define GPIO_SMT_DIS   (0 << GPIO_SMT_SHIFT)
+#define GPIO_SMT_EN    (1 << GPIO_SMT_SHIFT)
+
+/* GPIO type selection:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... .... FFFF
+ */
+
+#define GPIO_FUNC_SHIFT  (0) /* Bits 0-3: GPIO Type */
+#define GPIO_FUNC_MASK   (15 << GPIO_FUNC_SHIFT)
+#define GPIO_FUNC_SDIO   (1  << GPIO_FUNC_SHIFT)  /* SDIO */
+#define GPIO_FUNC_FLASH  (2  << GPIO_FUNC_SHIFT)  /* Flash */
+#define GPIO_FUNC_SPI    (4  << GPIO_FUNC_SHIFT)  /* SPI */
+#define GPIO_FUNC_I2C    (6  << GPIO_FUNC_SHIFT)  /* I2C */
+#define GPIO_FUNC_UART   (7  << GPIO_FUNC_SHIFT)  /* UART */
+#define GPIO_FUNC_PWM    (8  << GPIO_FUNC_SHIFT)  /* PWM */
+#define GPIO_FUNC_EXT_PA (9  << GPIO_FUNC_SHIFT)  /* Analog */
+#define GPIO_FUNC_ANA    (10 << GPIO_FUNC_SHIFT)  /* Analog */
+#define GPIO_FUNC_SWGPIO (11 << GPIO_FUNC_SHIFT)  /* Software GPIO */
+#define GPIO_FUNC_JTAG   (14 << GPIO_FUNC_SHIFT)  /* JTAG */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/* Must be big enough to hold the above encodings */
+
+typedef uint16_t gpio_pinattr_t;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_configgpio
+ *
+ * Description:
+ *   Configure a GPIO pin based on encoded pin attributes.
+ *
+ ****************************************************************************/
+
+int bl808_configgpio(int pin, gpio_pinattr_t attr);
+
+/****************************************************************************
+ * Name: bl808_gpiowrite
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void bl808_gpiowrite(int pin, bool value);
+
+/****************************************************************************
+ * Name: bl808_gpioread
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool bl808_gpioread(int pin);
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_BL808_BL808_GPIO_H */

--- a/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
+++ b/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
@@ -28,7 +28,7 @@
 /* Register Base Address ****************************************************/
 
 #define BL808_GLB_BASE     0x20000000ul
-
+#define BL808_GPIO_BASE    0x200008c4ul
 #define BL808_UART0_BASE   0x2000a000ul
 #define BL808_UART1_BASE   0x2000a100ul
 #define BL808_UART2_BASE   0x2000aa00ul

--- a/boards/risc-v/bl808/ox64/src/bl808_appinit.c
+++ b/boards/risc-v/bl808/ox64/src/bl808_appinit.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <syslog.h>
 #include <errno.h>
+#include <debug.h> ////
 
 #include <nuttx/board.h>
 #include <nuttx/drivers/ramdisk.h>
@@ -35,6 +36,7 @@
 #include <sys/boardctl.h>
 #include <arch/board/board_memorymap.h>
 #include "bl808_courier.h"
+#include "bl808_gpio.h" ////
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -169,4 +171,21 @@ void board_late_initialize(void)
   mount(NULL, "/proc", "procfs", 0, NULL);
 
 #endif
+
+  ////TODO
+  #define GPIO_PIN  29
+  #define GPIO_ATTR (GPIO_OUTPUT | GPIO_FUNC_SWGPIO)
+
+  _info("Config GPIO: pin=%d, attr=0x%x\n", GPIO_PIN, GPIO_ATTR);
+  int ret = bl808_configgpio(GPIO_PIN, GPIO_ATTR);
+  DEBUGASSERT(ret == OK);
+  up_mdelay(100);
+
+  _info("Set GPIO: pin=%d\n", GPIO_PIN);
+  bl808_gpiowrite(GPIO_PIN, true);
+  up_mdelay(100);
+
+  _info("Clear GPIO: pin=%d\n", GPIO_PIN);
+  bl808_gpiowrite(GPIO_PIN, false);
+  up_mdelay(100);
 }


### PR DESCRIPTION
## Summary

## Impact

## Testing

GPIO Driver tested OK on Ox64 Emulator

```bash
rm: init.S: No such file or directory
rm: initrd: No such file or directory
+ git pull
Already up to date.
+ git status
On branch gpio5
Your branch is up to date with 'origin/gpio5'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   boards/risc-v/bl808/ox64/src/bl808_appinit.c

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        boards/risc-v/bl808/ox64/scripts/ld.script.tmp

no changes added to commit (use "git add" and/or "git commit -a")
++ git rev-parse HEAD
+ hash1=8cc3ee4f06303ff54878f74fa82740d2c9bb8fdd
+ pushd ../apps
~/ox64/apps ~/ox64/nuttx
+ git pull
Already up to date.
+ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
++ git rev-parse HEAD
+ hash2=2e5a269e7f8ad60ccf7bc30c4f92ece4b9956a2a
+ popd
~/ox64/nuttx
+ echo NuttX Source: https://github.com/apache/nuttx/tree/8cc3ee4f06303ff54878f74fa82740d2c9bb8fdd
+ echo NuttX Apps: https://github.com/apache/nuttx-apps/tree/2e5a269e7f8ad60ccf7bc30c4f92ece4b9956a2a
+ riscv-none-elf-gcc -v
Using built-in specs.
COLLECT_GCC=riscv-none-elf-gcc
COLLECT_LTO_WRAPPER=/Users/luppy/xpack-riscv-none-elf-gcc-13.2.0-2/bin/../libexec/gcc/riscv-none-elf/13.2.0/lto-wrapper
Target: riscv-none-elf
Configured with: /Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/sources/gcc-13.2.0/configure --prefix=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/application --with-sysroot=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/application/riscv-none-elf --with-native-system-header-dir=/include --infodir=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/aarch64-apple-darwin20.6.0/install/share/info --mandir=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/aarch64-apple-darwin20.6.0/install/share/man --htmldir=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/aarch64-apple-darwin20.6.0/install/share/html --pdfdir=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/aarch64-apple-darwin20.6.0/install/share/pdf --build=aarch64-apple-darwin20.6.0 --host=aarch64-apple-darwin20.6.0 --target=riscv-none-elf --disable-libgomp --disable-libmudflap --disable-libquadmath --disable-libsanitizer --disable-libssp --disable-nls --disable-shared --disable-threads --disable-tls --enable-checking=release --enable-languages=c,c++,fortran --with-gmp=/Users/ilg/actions-runners/xpack-dev-tools/_work/riscv-none-elf-gcc-xpack/riscv-none-elf-gcc-xpack/build/darwin-arm64/aarch64-apple-darwin20.6.0/install --with-newlib --with-pkgversion='xPack GNU RISC-V Embedded GCC arm64' --with-gnu-as --with-gnu-ld --with-system-zlib --with-abi=ilp32 --with-arch=rv32imac --enable-multilib
Thread model: single
Supported LTO compression algorithms: zlib zstd
gcc version 13.2.0 (xPack GNU RISC-V Embedded GCC arm64) 
+ tools/configure.sh ox64:nsh
No configuration change.
+ build_nuttx
+ pushd ../nuttx
~/ox64/nuttx ~/ox64/nuttx
+ make -j 8
LD: nuttx
CP: nuttx.hex
+ popd
~/ox64/nuttx
+ build_rust
+ build_apps
+ pushd ../nuttx
~/ox64/nuttx ~/ox64/nuttx
+ make -j 8 export
+ pushd ../apps
~/ox64/apps ~/ox64/nuttx ~/ox64/nuttx
+ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-12.4.0.tar.gz
+ make -j 8 import
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 /Users/luppy/ox64/apps/import/tools/mkdeps.c -o /Users/luppy/ox64/apps/import/tools/mkdeps
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 /Users/luppy/ox64/apps/import/tools/incdir.c -o "/Users/luppy/ox64/apps/import/tools/incdir"
LN: platform/board to /Users/luppy/ox64/apps/platform/dummy
make[2]: Nothing to be done for `context_wasm'.
make[1]: Nothing to be done for `register'.
cp nsh_parse.c.Users.luppy.ox64.apps.nshlib.o  nsh_parse.c.Users.luppy.ox64.apps.nshlib_1.o
+ popd
~/ox64/nuttx ~/ox64/nuttx
+ popd
~/ox64/nuttx
+ rustup target add riscv64gc-unknown-none-elf
info: component 'rust-std' for target 'riscv64gc-unknown-none-elf' is up to date
+ pushd ../apps/examples/hello_rust
~/ox64/apps/examples/hello_rust ~/ox64/nuttx
++ basename ../hello/hello_main.c.Users.luppy.ox64.apps.examples.hello.o
+ hello=hello_main.c.Users.luppy.ox64.apps.examples.hello.o
++ echo hello_main.c.Users.luppy.ox64.apps.examples.hello.o
++ sed s/hello_main.c/hello_rust_main.rs/
++ sed s/hello.o/hello_rust.o/
+ hello_rust=hello_rust_main.rs.Users.luppy.ox64.apps.examples.hello_rust.o
+ rustc --target riscv64gc-unknown-none-elf --edition 2021 --emit obj -g -C panic=abort -O hello_rust_main.rs -o hello_rust_main.rs.Users.luppy.ox64.apps.examples.hello_rust.o
+ popd
~/ox64/nuttx
+ build_apps
+ pushd ../nuttx
~/ox64/nuttx ~/ox64/nuttx
+ make -j 8 export
+ pushd ../apps
~/ox64/apps ~/ox64/nuttx ~/ox64/nuttx
+ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-12.4.0.tar.gz
+ make -j 8 import
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 /Users/luppy/ox64/apps/import/tools/mkdeps.c -o /Users/luppy/ox64/apps/import/tools/mkdeps
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 /Users/luppy/ox64/apps/import/tools/incdir.c -o "/Users/luppy/ox64/apps/import/tools/incdir"
LN: platform/board to /Users/luppy/ox64/apps/platform/dummy
make[2]: Nothing to be done for `context_wasm'.
make[1]: Nothing to be done for `register'.
+ popd
~/ox64/nuttx ~/ox64/nuttx
+ popd
~/ox64/nuttx
+ rm -f /tmp/pattern.txt
+ start=570779904
+ set +x
+ cat /tmp/pattern.txt
+ xxd -revert -plain
+ genromfs -f initrd -d ../apps/bin -V NuttXBootVol
+ riscv-none-elf-size nuttx
   text    data     bss     dec     hex filename
 173030    1481   33488  207999   32c7f nuttx
+ riscv-none-elf-objcopy -O binary nuttx nuttx.bin
+ head -c 65536 /dev/zero
+ cat nuttx.bin /tmp/nuttx.pad initrd
+ cp .config nuttx.config
+ riscv-none-elf-objdump --syms --source --reloc --demangle --line-numbers --wide --debugging nuttx
+ riscv-none-elf-objdump --syms --source --reloc --demangle --line-numbers --wide --debugging ../apps/bin/init
+ riscv-none-elf-objdump --syms --source --reloc --demangle --line-numbers --wide --debugging ../apps/bin/hello
+ ../nxstyle arch/risc-v/src/bl808/bl808_gpio.c
+ ../nxstyle arch/risc-v/src/bl808/bl808_gpio.h
+ ../nxstyle arch/risc-v/src/bl808/hardware/bl808_memorymap.h
+ set -e
+ cp /Users/luppy/riscv/nuttx-tinyemu/docs/quickjs/root-riscv64.cfg .
+ /Users/luppy/riscv/ox64-tinyemu/temu root-riscv64.cfg
TinyEMU Emulator for Ox64 BL808 RISC-V SBC
virtio_console_init
Patched DCACHE.IALL (Invalidate all Page Table Entries in the D-Cache) at 0x50200bf6
Patched SYNC.S (Ensure that all Cache Operations are completed) at 0x50200bfa
Found ECALL (Start System Timer) at 0x5020c3d4
Patched RDTIME (Read System Time) at 0x5020c3da
elf_len=0
virtio_console_resize_event
ABCboard_late_initialize: Config GPIO: pin=29, attr=0xb
{"nuttxemu":{"gpio29":0}}
board_late_initialize: Set GPIO: pin=29
{"nuttxemu":{"gpio29":1}}
board_late_initialize: Clear GPIO: pin=29
{"nuttxemu":{"gpio29":0}}

NuttShell (NSH) NuttX-12.4.0
nsh> hello
Hello, World!!
nsh> free
                 total       used       free    maxused    maxfree  nused  nfree
      Kmem:    2057208      10792    2046416      36176    2042848     38      4
      Page:   20971520     647168   20324352   20324352
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=6

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="user_main"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        2
mxordblk    7cff0    7cff0
uordblks     2678     2678
fordblks    7e980    7e980

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        2
mxordblk    7cff0    7cff0
uordblks     2678     2678
fordblks    7e980    7e980

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        2
mxordblk    7cff0    7cff0
uordblks     2678     2678
fordblks    7e980    7e980
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        3
mxordblk    7cff0    7cff0
uordblks     2678     2658
fordblks    7e980    7e9a0
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        2
mxordblk    7cff0    7cff0
uordblks     2658     2578
fordblks    7e9a0    7ea80

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        2
mxordblk    7cff0    7cff0
uordblks     2578     2578
fordblks    7ea80    7ea80

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        2
mxordblk    7cff0    7cff0
uordblks     2578     2578
fordblks    7ea80    7ea80

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        4
mxordblk    7cff0    787f0
uordblks     2578     3598
fordblks    7ea80    7da60

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4        3
mxordblk    787f0    7a7f0
uordblks     3598     2d88
fordblks    7da60    7e270

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        3
mxordblk    7a7f0    78ff0
uordblks     2d88     4588
fordblks    7e270    7ca70

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        3
mxordblk    78ff0    78ff0
uordblks     4588     4588
fordblks    7ca70    7ca70

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 128
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        5
mxordblk    78ff0    767f0
uordblks     4588     3da8
fordblks    7ca70    7d250

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (163 sec, 620000000 nsec)
AFTER:  (165 sec, 745000000 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (165 sec, 745000000 nsec)
AFTER:  (166 sec, 746000000 nsec)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         5        3
mxordblk    767f0    7a7f0
uordblks     3da8     2d88
fordblks    7d250    7e270

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        3
mxordblk    7a7f0    787f0
uordblks     2d88     2d88
fordblks    7e270    7e270

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=25
pthread_exit_main 25: Starting pthread_exit_thread
pthread_exit_main 25: Sleeping for 5 seconds
pthread_exit_thread 26: Sleeping for 10 second
pthread_exit_main 25: Calling pthread_exit()
pthread_exit_thread 26: Still running...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        4
mxordblk    787f0    767f0
uordblks     2d88     4d98
fordblks    7e270    7c260

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 26: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4        5
mxordblk    767f0    747f0
uordblks     4d98     3da8
fordblks    7c260    7d250

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         5        2
mxordblk    747f0    7cff0
uordblks     3da8     2578
fordblks    7d250    7ea80

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        3
mxordblk    7cff0    7a7f0
uordblks     2578     2d88
fordblks    7ea80    7e270

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        4
mxordblk    7a7f0    74ff0
uordblks     2d88     6598
fordblks    7e270    7aa60

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4        3
mxordblk    74ff0    78ff0
uordblks     6598     4588
fordblks    7aa60    7ca70

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        3
mxordblk    78ff0    78ff0
uordblks     4588     4588
fordblks    7ca70    7ca70

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Unmasking SIGCHLD
sighand_test: Registering SIGCHLD handler
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=43
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=43 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        3
mxordblk    78ff0    78ff0
uordblks     4588     4588
fordblks    7ca70    7ca70

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=44
signest_test: Starting interfering task at priority 102
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=45
signest_test: Simple case:
  Total signalled 1240  Odd=620 Even=620
  Total handled   1240  Odd=620 Even=620
  Total nested    0    Odd=0   Even=0  
signest_test: With task locking
  Total signalled 2480  Odd=1240 Even=1240
  Total handled   2480  Odd=1240 Even=1240
  Total nested    0    Odd=0   Even=0  
signest_test: With intefering thread
  Total signalled 3720  Odd=1860 Even=1860
  Total handled   3720  Odd=1860 Even=1860
  Total nested    0    Odd=0   Even=0  
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         3        4
mxordblk    78ff0    74ff0
uordblks     4588     6598
fordblks    7ca70    7aa60

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0x800084d4 oact.sa_flags=0 oact.sa_mask=2aaaaaaaaaaaaaaa
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=4
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=5
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4        4
mxordblk    74ff0    74ff0
uordblks     6598     6598
fordblks    7aa60    7aa60

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
         First get_primes_thread: 46
rr_test: Starting second get_primes_thread
         Second get_primes_thread: 47
rr_test: Waiting for threads to complete -- this should take awhile
         If RR scheduling is working, they should start and complete at
         about the same time
get_primes_thread id=1 started, looking for primes < 10000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 10000, doing 10 run(s)
get_primes_thread id=2 finished, found 1230 primes, last one was 9973
get_primes_thread id=1 finished, found 1230 primes, last one was 9973
rr_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4        4
mxordblk    74ff0    787f0
uordblks     6598     3598
fordblks    7aa60    7da60

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_test: Thread 0 completed with result=0
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_test: Thread 3 completed with result=0
barrier_test: Thread 4 completed with result=0
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         4       10
mxordblk    787f0    6c7f0
uordblks     3598     65f8
fordblks    7da60    7aa00

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks        10        4
mxordblk    6c7f0    787f0
uordblks     65f8     3598
fordblks    7aa00    7da60

user_main: vfork() test DISABLED (CONFIG_BUILD_KERNEL)

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       80ff8    80ff8
ordblks         2        4
mxordblk    7cff0    787f0
uordblks     2678     3598
fordblks    7e980    7da60
user_main: Exiting
ostest_main: Exiting with status 0
nsh> Terminated
+ rm root-riscv64.cfg
+ exit
 *  Terminal will be reused by tasks, press any key to close it. 

```