### PR TITLE
build.yml: Limit the GitHub Runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,13 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     strategy:
+      max-parallel: 12
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
+        boards: [
+          arm-01, other, risc-v-01, sim-01, xtensa-01,
+          arm-02, risc-v-02, sim-02, xtensa-02,
+          arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13
+        ]
 
     steps:
       - name: Download Source Artifact
@@ -178,6 +183,7 @@ jobs:
     runs-on: macos-13
     needs: Fetch-Source
     strategy:
+      max-parallel: 2
       matrix:
         boards: [macos, sim-01, sim-02]
     steps:
@@ -225,6 +231,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         boards: [msys2]
 


### PR DESCRIPTION
## Summary

This PR modifies NuttX CI and GitHub Actions, to comply with ASF Policy. Right now, every NuttX Pull Request will trigger 24 Concurrent Jobs (GitHub Runners), executing them in parallel: https://lupyuen.github.io/articles/ci

According to ASF Policy: We should run at most 15 Concurrent Jobs: https://infra.apache.org/github-actions-policy.html

Thus we'll cut down the Concurrent Jobs from 24 down to 15. That's 12 Linux Jobs, 2 macOS, 1 Windows. (Each job takes 30 mins to 2 hours)

(1) Right now our "Linux > Strategy" is a flat list of 20 Linux Jobs, all executed in parallel...
```yaml
      matrix:
        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
```

(2) We change "Linux > Strategy" to prioritise by Target Architecture, and limit to 12 concurrent jobs...
```yaml
      max-parallel: 12
      matrix:
        boards: [
          arm-01, other, risc-v-01, sim-01, xtensa-01,
          arm-02, risc-v-02, sim-02, xtensa-02,
          arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13
        ]
```

(3) So NuttX CI will initially execute 12 Build Jobs across Arm32, Arm64, RISC-V, Simulator and Xtensa. As they complete, NuttX CI will execute the remaining 8 Build Jobs (for Arm32).

(4) This will extend the Overall Build Duration from [2 hours](https://github.com/apache/nuttx/actions/runs/10817443237) to [2.25 hours](https://github.com/lupyuen4/ci-nuttx/actions/runs/10828246630)

(5) We'll also limit macOS Jobs to 2, Windows Jobs to 1

## Impact

This PR will extend the Overall Build Duration from [2 hours](https://github.com/apache/nuttx/actions/runs/10817443237) to [2.25 hours](https://github.com/lupyuen4/ci-nuttx/actions/runs/10828246630)

## Testing

We tested the CI here: https://github.com/lupyuen4/ci-nuttx/actions/runs/10828246630

It complies with ASF Policy: The GitHub Runners did not exceed 15 during the build.
