### PR TITLE
CI: Set PR Label to the Arch-Specific Board

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,6 +88,72 @@
   - changed-files:
       - any-glob-to-any-file: 'arch/z80/**'
 
+# add board labels
+
+"Board: arm":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/arm/**'
+
+"Board: arm64":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/arm64/**'
+
+"Board: avr":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/avr/**'
+
+"Board: hc":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/hc/**'
+
+"Board: mips":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/mips/**'
+
+"Board: openrisc":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/or1k/**'
+
+"Board: renesas":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/renesas/**'
+
+"Board: risc-v":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/risc-v/**'
+
+"Board: simulator":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/sim/**'
+
+"Board: sparc":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/sparc/**'
+
+"Board: tricore":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/tricore/**'
+
+"Board: x86":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/x86/**'
+
+"Board: x86_64":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/x86_64/**'
+
+"Board: xtensa":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/xtensa/**'
+
+"Board: z16":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/z16/**'
+
+"Board: z80":
+  - changed-files:
+      - any-glob-to-any-file: 'boards/z80/**'
+
 # add area labels
 
 "Area: Audio":
@@ -106,10 +172,6 @@
       - any-glob-to-any-file: 'wireless/bluetooth/**'
       - any-glob-to-any-file: 'nuttx/drivers/wireless/bluetooth/**'
       - any-glob-to-any-file: 'include/nuttx/wireless/bluetooth/**'
-
-"Area: Board support":
-  - changed-files:
-      - any-glob-to-any-file: 'boards/**'
 
 "Area: Build system":
   - changed-files:


### PR DESCRIPTION
## Summary

This PR changes the Labeling of PRs so that the Architecture (arm, risc-v, xtensa, ...) is specified in the Board Label. Previously the CI Workflow would set Generic Board Labels like "Area: Board support". Now it will set the Arch-Specific Board Label like "Board: arm".

The Board Label will be used by the upcoming CI Build Rules to skip unnecessary builds. So "Board: arm" will enable only the builds for `arm-01` to `arm-14`. This is explained here: https://github.com/apache/nuttx/issues/13775

## Impact

No impact, since the current label "Area: Board support" is not used by the CI Build Rules.

The Updated CI Workflow shall be synced to `nuttx-apps` repo in the next PR.

## Testing

We tested the Board Labeling by creating Board PRs for each Arch:
- [Arm32 PR](https://github.com/lupyuen5/label-nuttx/pull/30) is labeled "Board: arm"
- [Arm64 PR](https://github.com/lupyuen5/label-nuttx/pull/31) is labeled "Board: arm64"
- [RISC-V PR](https://github.com/lupyuen5/label-nuttx/pull/32) is labeled "Board: risc-v"
- [Simulator PR](https://github.com/lupyuen5/label-nuttx/pull/33) is labeled "Board: simulator"
- [x86_64 PR](https://github.com/lupyuen5/label-nuttx/pull/34) is labeled "Board: x86_64"
- [Xtensa PR](https://github.com/lupyuen5/label-nuttx/pull/35) is labeled "Board: xtensa"
