### PR TITLE
arch/arm64/a527: Add support for Allwinner A527 SoC

### DIFF
--- a/Documentation/platforms/arm64/a527/index.rst
+++ b/Documentation/platforms/arm64/a527/index.rst
@@ -1,0 +1,9 @@
+==============
+Allwinner A527
+==============
+
+`Allwinner A527 <https://linux-sunxi.org/A523>`_ is an ARM64 SoC that features:
+
+- **CPU:** Octa-Core ARM Cortex-A55
+- **GPU:** ARM G57 MC1
+- **Interrupt Controller:** ARM GIC-600 (Generic Interrupt Controller v3)

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -37,6 +37,22 @@ config ARCH_CHIP_A64
 	---help---
 		Allwinner A64 SoC
 
+config ARCH_CHIP_A527
+	bool "Allwinner A572"
+	select ARCH_CORTEX_A55
+	select ARCH_HAVE_MULTICPU
+	select ARMV8A_HAVE_GICv3
+	select ARCH_HAVE_ADDRENV
+	select ARCH_HAVE_ELF_EXECUTABLE
+	select ARCH_HAVE_IRQTRIGGER
+	select ARCH_NEED_ADDRENV_MAPPING
+	select ARCH_HAVE_POWEROFF
+	select ARCH_HAVE_RESET
+	select ARCH_HAVE_TEXT_HEAP
+	select ARM64_HAVE_PSCI
+	---help---
+		Allwinner A527 SoC
+
 config ARCH_CHIP_RK3399
 	bool "Rockchip RK3399"
 	select ARCH_CORTEX_A53
@@ -325,6 +341,7 @@ config ARCH_FAMILY
 config ARCH_CHIP
 	string
 	default "a64"       if ARCH_CHIP_A64
+	default "a527"      if ARCH_CHIP_A527
 	default "rk3399"    if ARCH_CHIP_RK3399
 	default "zynq-mpsoc" if ARCH_CHIP_ZYNQ_MPSOC
 	default "qemu"      if ARCH_CHIP_QEMU
@@ -465,6 +482,10 @@ config ARM64_PA_BITS
 
 if ARCH_CHIP_A64
 source "arch/arm64/src/a64/Kconfig"
+endif
+
+if ARCH_CHIP_A527
+source "arch/arm64/src/a527/Kconfig"
 endif
 
 if ARCH_CHIP_RK3399

--- a/arch/arm64/include/a527/chip.h
+++ b/arch/arm64/include/a527/chip.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+ * arch/arm64/include/a527/chip.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_INCLUDE_A527_CHIP_H
+#define __ARCH_ARM64_INCLUDE_A527_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Number of bytes in x kibibytes/mebibytes/gibibytes */
+
+#define KB(x)           ((x) << 10)
+#define MB(x)           (KB(x) << 10)
+#define GB(x)           (MB(UINT64_C(x)) << 10)
+
+/* Generic Interrupt Controller v3: Distributor and Redistributor */
+
+#define CONFIG_GICD_BASE           0x3400000
+#define CONFIG_GICR_BASE           0x3460000
+#define CONFIG_GICR_OFFSET         0x20000
+
+/* Memory Map: RAM and I/O Memory */
+
+#define CONFIG_RAMBANK1_ADDR       0x40000000
+#define CONFIG_RAMBANK1_SIZE       MB(128)
+
+#define CONFIG_DEVICEIO_BASEADDR   0x00000000
+#define CONFIG_DEVICEIO_SIZE       MB(1024)
+
+/* Bootloader loads NuttX at this address */
+
+#define CONFIG_LOAD_BASE           0x40800000
+
+/* GIC Cluster Mapping */
+
+#define MPID_TO_CLUSTER_ID(mpid)   ((mpid) & ~0xff)
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+.macro  get_cpu_id xreg0
+  mrs    \xreg0, mpidr_el1
+  ubfx   \xreg0, \xreg0, #0, #8
+.endm
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_ARM64_INCLUDE_A527_CHIP_H */

--- a/arch/arm64/include/a527/irq.h
+++ b/arch/arm64/include/a527/irq.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/arm64/include/a527/irq.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* This file should never be included directly but, rather,
+ * only indirectly through nuttx/irq.h
+ */
+
+#ifndef __ARCH_ARM64_INCLUDE_A527_IRQ_H
+#define __ARCH_ARM64_INCLUDE_A527_IRQ_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Total number of interrupts */
+
+#define NR_IRQS            220
+
+/* Map CPU MPID to Core ID */
+
+#define MPID_TO_CORE(mpid) (((mpid) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
+
+#endif /* __ARCH_ARM64_INCLUDE_A527_IRQ_H */

--- a/arch/arm64/src/a527/CMakeLists.txt
+++ b/arch/arm64/src/a527/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# arch/arm64/src/a527/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+set(SRCS a527_boot.c a527_serial.c a527_timer.c)
+
+if(CONFIG_ARCH_EARLY_PRINT)
+  list(APPEND SRCS a527_lowputc.S)
+endif()
+if(CONFIG_ARCH_USE_TEXT_HEAP)
+  list(APPEND SRCS a527_textheap.c)
+endif()
+if(CONFIG_PM)
+  list(APPEND SRCS a527_initialize.c)
+endif()
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm64/src/a527/Make.defs
+++ b/arch/arm64/src/a527/Make.defs
@@ -1,0 +1,38 @@
+############################################################################
+# arch/arm64/src/a527/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include common/Make.defs
+
+# C Source Files specific to SoC
+CHIP_CSRCS  = a527_boot.c a527_serial.c a527_timer.c
+
+ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
+CHIP_ASRCS  = a527_lowputc.S
+endif
+
+ifeq ($(CONFIG_ARCH_USE_TEXT_HEAP),y)
+CHIP_CSRCS += a527_textheap.c
+endif
+
+ifeq ($(CONFIG_PM), y)
+CHIP_CSRCS += a527_initialize.c
+endif

--- a/arch/arm64/src/a527/a527_boot.c
+++ b/arch/arm64/src/a527/a527_boot.c
@@ -1,0 +1,268 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_boot.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/compiler.h>
+#include <nuttx/cache.h>
+#include <nuttx/syslog/syslog_rpmsg.h>
+#include <arch/chip/chip.h>
+#include <arch/board/board_memorymap.h>
+
+#ifdef CONFIG_SMP
+#include "arm64_smp.h"
+#endif
+
+#include "arm64_arch.h"
+#include "arm64_internal.h"
+#include "arm64_mmu.h"
+#include "a527_boot.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* MMU Memory Regions for I/O Memory and RAM */
+
+static const struct arm_mmu_region g_mmu_regions[] =
+{
+  MMU_REGION_FLAT_ENTRY("DEVICE_REGION",
+                        CONFIG_DEVICEIO_BASEADDR, CONFIG_DEVICEIO_SIZE,
+                        MT_DEVICE_NGNRNE | MT_RW | MT_SECURE),
+
+  MMU_REGION_FLAT_ENTRY("DRAM0_S0",
+                        CONFIG_RAMBANK1_ADDR, CONFIG_RAMBANK1_SIZE,
+                        MT_NORMAL | MT_RW | MT_SECURE),
+};
+
+const struct arm_mmu_config g_mmu_config =
+{
+  .num_regions = nitems(g_mmu_regions),
+  .mmu_regions = g_mmu_regions,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: a527_copy_overlap
+ *
+ * Description:
+ *   Copy an overlapping memory region.  dest overlaps with src + count.
+ *
+ * Input Parameters:
+ *   dest  - Destination address
+ *   src   - Source address
+ *   count - Number of bytes to copy
+ *
+ ****************************************************************************/
+
+static void a527_copy_overlap(uint8_t *dest, const uint8_t *src,
+                              size_t count)
+{
+  uint8_t *d = dest + count - 1;
+  const uint8_t *s = src + count - 1;
+
+  if (dest <= src)
+    {
+      _err("dest and src should overlap");
+      PANIC();
+    }
+
+  while (count--)
+    {
+      volatile uint8_t c = *s;  /* Prevent compiler optimization */
+      *d = c;
+      d--;
+      s--;
+    }
+}
+
+/****************************************************************************
+ * Name: a527_copy_ramdisk
+ *
+ * Description:
+ *   Copy the RAM Disk from NuttX Image to RAM Disk Region.
+ *
+ ****************************************************************************/
+
+static void a527_copy_ramdisk(void)
+{
+  const uint8_t aligned_data(8) header[8] = "-rom1fs-";
+  const uint8_t *limit = (uint8_t *)g_idle_topstack + (256 * 1024);
+  uint8_t *ramdisk_addr = NULL;
+  uint8_t *addr;
+  uint32_t size;
+
+  /* After Idle Stack Top, search for "-rom1fs-". This is the RAM Disk
+   * Address. Limit search to 256 KB after Idle Stack Top.
+   */
+
+  binfo("_edata=%p, _sbss=%p, _ebss=%p, idlestack_top=%p\n",
+        (void *)_edata, (void *)_sbss, (void *)_ebss,
+        (void *)g_idle_topstack);
+  for (addr = g_idle_topstack; addr < limit; addr += 8)
+    {
+      if (memcmp(addr, header, sizeof(header)) == 0)
+        {
+          ramdisk_addr = addr;
+          break;
+        }
+    }
+
+  /* Stop if RAM Disk is missing */
+
+  binfo("ramdisk_addr=%p\n", ramdisk_addr);
+  if (ramdisk_addr == NULL)
+    {
+      _err("Missing RAM Disk. Check the initrd padding.");
+      PANIC();
+    }
+
+  /* Read the Filesystem Size from the next 4 bytes (Big Endian) */
+
+  size = (ramdisk_addr[8] << 24) + (ramdisk_addr[9] << 16) +
+         (ramdisk_addr[10] << 8) + ramdisk_addr[11] + 0x1f0;
+  binfo("size=%d\n", size);
+
+  /* Filesystem Size must be less than RAM Disk Memory Region */
+
+  if (size > (size_t)__ramdisk_size)
+    {
+      _err("RAM Disk Region too small. Increase by %lu bytes.\n",
+            size - (size_t)__ramdisk_size);
+      PANIC();
+    }
+
+  /* Copy the RAM Disk from NuttX Image to RAM Disk Region.
+   * __ramdisk_start overlaps with ramdisk_addr + size.
+   */
+
+  a527_copy_overlap(__ramdisk_start, ramdisk_addr, size);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+
+/****************************************************************************
+ * Name: arm64_get_mpid
+ *
+ * Description:
+ *   This function maps the CPU Index to CPU MPID, by reading the mpidr_el1
+ *   register. Different ARM64 Cores will define affinity differently, so
+ *   the mpidr_el1 value might not be the CPU Index. We need to map the
+ *   CPU Index to MPID and vice versa.
+ *
+ ****************************************************************************/
+
+uint64_t arm64_get_mpid(int cpu)
+{
+  return CORE_TO_MPID(cpu, 0);
+}
+
+/****************************************************************************
+ * Name: arm64_get_cpuid
+ *
+ * Description:
+ *   This function maps the CPU MPID to CPU Index.
+ *
+ ****************************************************************************/
+
+int arm64_get_cpuid(uint64_t mpid)
+{
+  return MPID_TO_CORE(mpid);
+}
+
+#endif /* CONFIG_SMP */
+
+/****************************************************************************
+ * Name: arm64_el_init
+ *
+ * Description:
+ *   The function is called by arm64_head.S at the early stage to:
+ *   - Initialize special hardware that should run at high ELs
+ *   - Initialize system software that should run at high ELs,
+ *     such as hypervisor or security firmware
+ *
+ ****************************************************************************/
+
+void arm64_el_init(void)
+{
+}
+
+/****************************************************************************
+ * Name: arm64_chip_boot
+ *
+ * Description:
+ *   Complete the boot operations started in arm64_head.S
+ *
+ ****************************************************************************/
+
+void arm64_chip_boot(void)
+{
+  /* Copy the RAM Disk */
+
+  a527_copy_ramdisk();
+
+  /* Map the RAM and I/O Memory, enable the MMU */
+
+  arm64_mmu_init(true);
+
+  /* Optional: Enable the Memory Tagging Extension */
+
+  arm64_enable_mte();
+
+#if defined(CONFIG_ARM64_PSCI)
+  /* Init the Power State Coordination Interface */
+
+  arm64_psci_init("smc");
+#endif
+
+  /* Perform board-specific device initialization. This would include
+   * configuration of board specific resources such as GPIOs, LEDs, etc.
+   */
+
+  a527_board_initialize();
+
+#ifdef USE_EARLYSERIALINIT
+  /* Perform early serial initialization if we are going to use the serial
+   * driver.
+   */
+
+  arm64_earlyserialinit();
+#endif
+
+#ifdef CONFIG_ARCH_PERF_EVENTS
+  up_perf_init((void *)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+#endif
+}

--- a/arch/arm64/src/a527/a527_boot.h
+++ b/arch/arm64/src/a527/a527_boot.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_boot.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_A527_A527_BOOT_H
+#define __ARCH_ARM64_SRC_A527_A527_BOOT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <arch/chip/chip.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC  62500000
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: a527_board_initialize
+ *
+ * Description:
+ *   All A527 architectures must provide the following entry point.  This
+ *   entry point is called in the initialization phase -- after
+ *   a527_memory_initialize and after all memory has been configured and
+ *   mapped but before any devices have been initialized.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void a527_board_initialize(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_ARM64_SRC_A527_A527_BOOT_H */

--- a/arch/arm64/src/a527/a527_initialize.c
+++ b/arch/arm64/src/a527/a527_initialize.c
@@ -1,0 +1,119 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_initialize.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/power/pm.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void arm64_pminitialize(void)
+{
+  pm_initialize();
+}
+
+#ifdef CONFIG_SMP
+static bool pm_idle_handler(int cpu,
+                            enum pm_state_e cpu_state,
+                            enum pm_state_e system_state)
+{
+  bool first = false;
+
+  switch (cpu_state)
+    {
+      case PM_NORMAL:
+      case PM_IDLE:
+      case PM_STANDBY:
+      case PM_SLEEP:
+
+        /* CPU Domain: PM Entry */
+
+        asm("NOP");
+
+        if (system_state >= PM_NORMAL)
+          {
+            switch (system_state)
+              {
+                case PM_NORMAL:
+                case PM_IDLE:
+                case PM_STANDBY:
+                case PM_SLEEP:
+
+                  /* System Domain: PM Entry */
+
+                  asm("NOP");
+
+                  break;
+                default:
+                  break;
+              }
+          }
+
+        pm_idle_unlock();
+
+        /* Operations here should not cross cores */
+
+        asm("WFI");
+
+        first = pm_idle_lock(cpu);
+        if (first)
+          {
+            /* System Domain: PM Exit */
+
+            asm("NOP");
+          }
+
+        /* CPU Domain: PM Exit */
+
+        asm("NOP");
+
+        break;
+      default:
+        break;
+    }
+
+  return first;
+}
+#else
+
+static void pm_idle_handler(enum pm_state_e state)
+{
+  switch (state)
+    {
+      default:
+        asm("WFI");
+        break;
+    }
+}
+
+#endif
+
+void up_idle(void)
+{
+  pm_idle(pm_idle_handler);
+}

--- a/arch/arm64/src/a527/a527_lowputc.S
+++ b/arch/arm64/src/a527/a527_lowputc.S
@@ -1,0 +1,80 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_lowputc.S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Arm64 Wrapper for early printing */
+
+#include <nuttx/config.h>
+#include "arm64_macro.inc"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+    .file    "a527_lowputc.S"
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+#define UART0_BASE_ADDRESS 0x02500000
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* 16550 UART initialization */
+
+GTEXT(arm64_earlyprintinit)
+SECTION_FUNC(text, arm64_earlyprintinit)
+    ret
+
+/* Wait for 16550 UART to be ready to transmit.
+ * xb: Register that contains the UART Base Address
+ * wt: Scratch register number
+ */
+
+.macro early_uart_ready xb, wt
+1:
+    ldrh  \wt, [\xb, #0x14]      /* UART_LSR (Line Status Register) */
+    tst   \wt, #0x20             /* Check THRE (TX Holding Register Empty) */
+    b.eq  1b                     /* Wait for the UART to be ready (THRE=1) */
+.endm
+
+/* 16550 UART transmit character.
+ * xb: Register that contains the UART Base Address
+ * wt: Register that contains the character to transmit
+ */
+
+.macro early_uart_transmit xb, wt
+    strb  \wt, [\xb]             /* -> UART_THR (TX Holding Register) */
+.endm
+
+/* Print a character on the UART. This function is called by C.
+ * x0: Character to print
+ */
+
+GTEXT(arm64_lowputc)
+SECTION_FUNC(text, arm64_lowputc)
+    ldr   x15, =UART0_BASE_ADDRESS
+    early_uart_ready    x15, w2
+    early_uart_transmit x15, w0
+    ret

--- a/arch/arm64/src/a527/a527_serial.c
+++ b/arch/arm64/src/a527/a527_serial.c
@@ -1,0 +1,75 @@
+/***************************************************************************
+ * arch/arm64/src/a527/a527_serial.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ***************************************************************************/
+
+/***************************************************************************
+ * Included Files
+ ***************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/serial/uart_16550.h>
+#include "arm64_internal.h"
+
+#ifdef USE_SERIALDRIVER
+/***************************************************************************
+ * Public Functions
+ ***************************************************************************/
+
+/***************************************************************************
+ * Name: arm64_earlyserialinit
+ *
+ * Description:
+ *   See arm64_internal.h
+ *
+ ***************************************************************************/
+
+void arm64_earlyserialinit(void)
+{
+  /* Enable the console UART.  The other UARTs will be initialized if and
+   * when they are first opened.
+   */
+
+  u16550_earlyserialinit();
+}
+
+/***************************************************************************
+ * Name: arm64_serialinit
+ *
+ * Description:
+ *   See arm64_internal.h
+ *
+ ***************************************************************************/
+
+void arm64_serialinit(void)
+{
+  u16550_serialinit();
+}
+
+#endif /* USE_SERIALDRIVER */

--- a/arch/arm64/src/a527/a527_textheap.c
+++ b/arch/arm64/src/a527/a527_textheap.c
@@ -1,0 +1,115 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_textheap.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+#include <nuttx/queue.h>
+#include <nuttx/kmalloc.h>
+
+#include "arm64_mmu.h"
+#include "arm64_internal.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern uint8_t _sload[];
+extern uint8_t _szload[];
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct mm_heap_s *g_textheap;
+
+/* Mark the Load Segment cacheable, write-read and executable */
+
+static struct arm_mmu_region g_mmu_load =
+  MMU_REGION_FLAT_ENTRY("nx_load",
+                        (uint64_t)_sload,
+                        (uint64_t)_szload,
+                        MT_NORMAL | MT_RW | MT_EXECUTE | MT_SECURE);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_textheap_memalign
+ *
+ * Description:
+ *   Allocate memory for Text Sections with the specified alignment.
+ *
+ ****************************************************************************/
+
+void *up_textheap_memalign(size_t align, size_t size)
+{
+  if (g_textheap == NULL)
+    {
+      if (arm64_mmu_set_memregion(&g_mmu_load) != 0)
+        {
+          return NULL;
+        }
+
+      g_textheap = mm_initialize("textheap", (void *)&_sload,
+                                 (size_t)_szload);
+    }
+
+  return mm_memalign(g_textheap, align, size);
+}
+
+/****************************************************************************
+ * Name: up_textheap_free
+ *
+ * Description:
+ *   Free the memory allocated for Text Sections.
+ *
+ ****************************************************************************/
+
+void up_textheap_free(void *p)
+{
+  if (g_textheap != NULL)
+    {
+      mm_free(g_textheap, p);
+    }
+}
+
+/****************************************************************************
+ * Name: up_textheap_heapmember
+ *
+ * Description:
+ *   Test if the memory is from Text Heap.
+ *
+ ****************************************************************************/
+
+bool up_textheap_heapmember(void *p)
+{
+  if (g_textheap != NULL)
+    {
+      return mm_heapmember(g_textheap, p);
+    }
+
+  return false;
+}

--- a/arch/arm64/src/a527/a527_timer.c
+++ b/arch/arm64/src/a527/a527_timer.c
@@ -1,0 +1,37 @@
+/****************************************************************************
+ * arch/arm64/src/a527/a527_timer.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/timers/arch_alarm.h>
+#include "arm64_arch_timer.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/a527/chip.h
+++ b/arch/arm64/src/a527/chip.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * arch/arm64/src/a527/chip.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_A527_CHIP_H
+#define __ARCH_ARM64_SRC_A527_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+#  include <nuttx/arch.h>
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+#endif /* __ARCH_ARM64_SRC_A527_CHIP_H */


### PR DESCRIPTION
## Summary

This PR adds support for the Allwinner A527 Arm64 SoC. This will be used by the upcoming port of NuttX for PINE64 Yuzuki Avaota-A1 SBC. And for Arm64 PR Test Bot.

Most of the code was derived from NuttX for QEMU Arm64 Kernel Build `qemu-armv8a:knsh`. [The modified code is explained here](https://lupyuen.github.io/articles/avaota#appendix-port-nuttx-to-avaota-a1)

### Modified Files in arch/arm64

`Kconfig`: Added ARCH_CHIP_A527 for A527 SoC

### New Files in arch/arm64

`include/a527/chip.h`: A527 Definitions

`include/a527/irq.h`: External Interrupts

`src/a527/chip.h`: Memory Map

`src/a527/a527_boot.c`, `a527_boot.h`: Startup Code

`src/a527/a527_initialize.c`: Power Management

`src/a527/a527_lowputc.S`: UART Output

`src/a527/a527_serial.c`: Serial Driver

`src/a527/a527_textheap.c`: Text Heap

`src/a527/a527_timer.c`: A527 Timer

`src/a527/Kconfig`: A527 Config

`src/a527/Make.defs`, `CMakeLists.txt`: Makefiles

### Documentation

`platforms/arm64/a527/index.rst`: Added A527 SoC

## Impact

This PR is needed for the upcoming port of NuttX for PINE64 Yuzuki Avaota-A1 SBC.

No impact on existing code, since the source files are not used by existing code.

## Testing

We tested the source files on PINE64 Yuzuki Avaota-A1 SBC. NuttX boots correctly to NSH Shell and passes OSTest:

- [Board Source Code](https://github.com/lupyuen2/wip-nuttx/pull/99/files)
- [NuttX Log](https://gist.github.com/lupyuen/6365762343133a843276bb87d2da17a1)
- [Build Log](https://gist.github.com/lupyuen/7296022328dadcfac88a38d4b3eec892)
- [Demo Video](https://youtu.be/XTDw245n5tM)

```text
- Ready to Boot Primary CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize

NuttShell (NSH) NuttX-12.4.0
nsh> uname -a
NuttX 12.4.0 42c0ed4a89 Mar 13 2025 09:13:56 arm64 avaota-a1

nsh> ls -l /dev
/dev:
 crw-rw-rw-           0 console
 crw-rw-rw-           0 null
 brw-rw-rw-    16777216 ram0
 crw-rw-rw-           0 ttyS0
 crw-rw-rw-           0 zero

nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008176 0000928  11.3%  Idle_Task
    1     0 192 RR       Kthread   - Waiting  Semaphore 0000000000000000 0008112 0000992  12.2%  hpwork 0x40833568 0x408335b8
    2     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0008112 0000992  12.2%  lpwork 0x408334e8 0x40833538
    4     4 100 RR       Task      - Running            0000000000000000 0008128 0002192  26.9%  /system/bin/init

nsh> free
      total       used       free    maxused    maxfree  nused  nfree name
  125542400      33880  125508520      53032  125484976     58      5 Kmem
    4194304     245760    3948544               3948544               Page

nsh> hello
Hello, World!!

nsh> getprime
Set thread priority to 10
Set thread policy to SCHED_RR
Start thread #0
thread #0 started, looking for primes < 10000, doing 10 run(s)
thread #0 finished, found 1230 primes, last one was 9973
Done
getprime took 162 msec

nsh> ostest
...
Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena        a000    26000
ordblks         2        4
mxordblk     6ff8    1aff8
uordblks     27e8     6700
fordblks     7818    1f900
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
